### PR TITLE
Change shebang for better compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 var notifier = require('node-notifier');
 var SlackChannel = /** @class */ (function () {
     function SlackChannel(team, id, name) {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 
 const notifier = require('node-notifier');
 


### PR DESCRIPTION
Using `/usr/bin/env node` is better than using `/usr/bin/local/node`.
`/usr/bin/local/node` is unavailable for users who use node with system
install or with nvm.